### PR TITLE
Specified encoding, included title for Reddit post data

### DIFF
--- a/examples/integration_test/integration_test.py
+++ b/examples/integration_test/integration_test.py
@@ -44,7 +44,7 @@ def test_rank_fake(url):
 
 
 def test_rank_facebook(url):
-    with open("test_data/facebook.csv") as f:
+    with open("test_data/facebook.csv", encoding="utf-8") as f:
         items = []
         reader = csv.DictReader(f)
         for row in reader:
@@ -89,7 +89,7 @@ def test_rank_facebook(url):
 
 
 def test_rank_reddit(url):
-    with open("test_data/reddit.csv") as f:
+    with open("test_data/reddit.csv", encoding="utf-8") as f:
         items = []
         reader = csv.DictReader(f)
         for row in reader:
@@ -109,6 +109,7 @@ def test_rank_reddit(url):
                     post_id=row["post_id"],
                     parent_id=row["parent_id"],
                     text=row["text"],
+                    title=row["title"],
                     author_name_hash=row["author_name_hash"],
                     type=row["type"].lower(),
                     created_at=row["created_at"],


### PR DESCRIPTION
1. On my system (Windows 10, Python 3.9), the automatically chosen encoding (see [here](https://docs.python.org/3/library/functions.html#open)) leads to a decoding error on the csv files, which is why it might sometimes help to specify utf-8.
2. The Reddit post title is missing, leading to some post requests with empty text content. This might cause trouble for some rankers.