### PR TITLE
Use links to real social media posts that exist, for testing

### DIFF
--- a/examples/fastapi_nltk/ranking_server.py
+++ b/examples/fastapi_nltk/ranking_server.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import inspect
+import random
 
 parentdir = os.path.dirname(  # make it possible to import from ../ in a reliable way
     os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
@@ -26,6 +27,8 @@ app = FastAPI(
     version="0.1.0",
 )
 
+# Set up CORS. This is necessary if calling this code directly from a
+# browser extension, but if you're not doing that, you won't need this.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -51,8 +54,8 @@ def rank(ranking_request: RankingRequest) -> RankingResponse:
     ranked_results.sort(key=lambda x: x["scores"]["compound"], reverse=True)
     ranked_ids = [content["id"] for content in ranked_results]
 
-    # Add a new post (not part of the candidate set) to the top of the result
-    new_post = NEW_POSTS[0]
+    # Add a random new post (not part of the candidate set) to the top of the result
+    new_post = NEW_POSTS[ranking_request.session.platform][random.randint(0, 1)]
     ranked_ids.insert(0, new_post["id"])
 
     result = {

--- a/examples/fastapi_nltk/ranking_server_test.py
+++ b/examples/fastapi_nltk/ranking_server_test.py
@@ -40,17 +40,11 @@ def test_rank(client):
     result = response.json()
 
     # Check if the response contains the expected ids, in the expected order
-    assert result["ranked_ids"] == [
-        "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+    assert result["ranked_ids"][1:4] == [
         "s5ad13266-8abk4-5219-kre5-2811022l7e43dv",
         "a4c08177-8db2-4507-acc1-1298220be98d",
         "de83fc78-d648-444e-b20d-853bf05e4f0e",
     ]
 
     # check for inserted posts
-    assert result["new_items"] == [
-        {
-            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
-            "url": "https://reddit.com/r/PRCExample/comments/1f33ead/example_to_insert",
-        }
-    ]
+    assert len(result["new_items"]) == 1

--- a/examples/fastapi_nltk/sample_data.py
+++ b/examples/fastapi_nltk/sample_data.py
@@ -45,13 +45,35 @@ BASIC_EXAMPLE = {
 }
 
 # some new posts that can be added to the response
-NEW_POSTS = [
-    {
-        "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
-        "url": "https://reddit.com/r/PRCExample/comments/1f33ead/example_to_insert",
-    },
-    {
-        "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
-        "url": "https://reddit.com/r/PRCExample/comments/ef56a23/another_example_to_insert",
-    },
-]
+NEW_POSTS = {
+    "facebook": [
+        {
+            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+            "url": "https://www.facebook.com/photo/?fbid=10160163058503437&set=a.10156555775028437",
+        },
+        {
+            "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
+            "url": "https://www.facebook.com/photo/?fbid=10160163060778437&set=a.10156555775028437",
+        },
+    ],
+    "reddit": [
+        {
+            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+            "url": "https://www.reddit.com/r/bestOfReddit/comments/hb55wg/rick_astley_gets_rick_rolled/",
+        },
+        {
+            "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
+            "url": "https://www.reddit.com/r/maru/comments/13co2hm/liquid_maru_with_level_10_of_meltability/",
+        },
+    ],
+    "twitter": [
+        {
+            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+            "url": "https://twitter.com/Horse_ebooks/status/218439593240956928",
+        },
+        {
+            "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
+            "url": "https://twitter.com/elonmusk/status/1519480761749016577",
+        },
+    ],
+}


### PR DESCRIPTION
We are testing the browser extension using this example, at least for the moment. It is helpful to be able to point at real social media posts that actually exist, and for them to be appropriate to the platform in question.