### PR TITLE
Add development example, update other examples to use simple-cors request

### DIFF
--- a/examples/development/README.md
+++ b/examples/development/README.md
@@ -1,0 +1,43 @@
+# Basic ranker example (random and reversed outputs)
+
+This ranker is for use in browser extension development. It can either reverse posts, or randomize them.
+
+## Data models
+
+This example uses [pydantic](https://docs.pydantic.dev/) to validate the schema for requests and responses.
+
+## Setting up your environment
+
+1. Create a virtual environment using your preferred method
+2. `pip install poetry`
+3. `poetry install --no-root` at the repo root. This will install only the dependencies listed in `pyproject.toml` without trying to install the current project as a package
+
+## Running tests
+
+Just run `pytest`
+
+## Running the service in development
+
+```bash
+uvicorn ranking_server:app --reload
+```
+
+This will spin up a server on `http://127.0.0.1:8000`
+
+## Executing your server outside of a unit test
+
+You can start the server and then run `caller.py` to send it data, or you can use the interface provided by FastAPI
+
+## Automatically-generated api docs
+
+With a running server, visit `http://127.0.0.1:8000/docs`. You can send requests from there too.
+
+## Running the service in production
+
+```bash
+uvicorn ranking_server:app --host 0.0.0.0 --port 5000
+```
+
+## Adding dependencies
+
+To add a new dependency use `poetry add <dependency>` and if it is package specific please move to extra in pyproject.toml

--- a/examples/development/caller.py
+++ b/examples/development/caller.py
@@ -1,0 +1,27 @@
+import time
+from pprint import pprint
+
+import requests
+
+import sample_data
+
+# This is a simple script that sends a POST request to the API and prints the response.
+# Your server should be running on localhost:8000
+
+# Wait for the Flask app to start up
+time.sleep(2)
+
+# Send POST request to the API
+response = requests.post("http://localhost:8000/rank", json=sample_data.BASIC_EXAMPLE)
+
+# Check if the request was successful (status code 200)
+if response.status_code == 200:
+    try:
+        # Attempt to parse the JSON response
+        json_response = response.json()
+        pprint(json_response)
+    except requests.exceptions.JSONDecodeError:
+        print("Failed to parse JSON response. Response may be empty.")
+else:
+    print(f"Request failed with status code: {response.status_code}")
+    print(response.text)

--- a/examples/development/ranking_server.py
+++ b/examples/development/ranking_server.py
@@ -1,0 +1,57 @@
+import random
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from ranking_challenge.request import RankingRequest
+from ranking_challenge.response import RankingResponse
+
+from sample_data import NEW_POSTS
+
+app = FastAPI(
+    title="Prosocial Ranking Challenge ranker development example",
+    description="Reorders ranking results in a random way for development purposes.",
+    version="0.1.0",
+)
+
+# Set up CORS. This is necessary if calling this code directly from a
+# browser extension, but if you're not doing that, you won't need this.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["HEAD", "OPTIONS", "GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/rank")
+async def rank(fastapi_req: Request) -> RankingResponse:
+    # Validating the json manually like this allows the request body to be text/plain or
+    # application/json. This allows the browser to consider the request "simple" CORS, and
+    # skips the preflight OPTIONS request. Doing it this way greatly simplifies working
+    # with proxies like cloudfront.
+    ranking_request = RankingRequest.model_validate_json(await fastapi_req.body())
+    ranked_ids = [content.id for content in ranking_request.items]
+
+    # uncomment one of these to change the ranker behaviora
+    # random.shuffle(ranked_ids)
+    ranked_ids = list(reversed(ranked_ids))
+
+    # delete one random item
+    # del ranked_ids[random.choice(range(len(ranked_ids)))]
+
+    # insert the first new post from the sample data
+    # new_post = NEW_POSTS[ranking_request.session.platform][0]
+    # ranked_ids.insert(2, new_post["id"])
+
+    result = {
+        "ranked_ids": ranked_ids,
+        # "new_items": [
+        #     {
+        #         "id": new_post["id"],
+        #         "url": new_post["url"],
+        #     }
+        # ],
+    }
+
+    return result

--- a/examples/development/ranking_server_test.py
+++ b/examples/development/ranking_server_test.py
@@ -1,0 +1,40 @@
+import json
+import sys
+
+sys.path.append(".")  # allows for importing from the current directory
+
+import pytest
+from fastapi.testclient import TestClient
+
+from development import ranking_server, sample_data
+
+
+@pytest.fixture
+def app():
+    app = ranking_server.app
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_rank(client):
+    # Send POST request to the API
+    response = client.post("/rank", json=sample_data.BASIC_EXAMPLE)
+
+    # Check if the request was successful (status code 200)
+    if response.status_code != 200:
+        print(f"Request failed with status code: {response.status_code}")
+        print(json.dumps(response.json(), indent=2))
+        assert False
+
+    result = response.json()
+
+    # Check if the response contains the expected ids, in the expected order
+    assert result["ranked_ids"] == [
+        "a4c08177-8db2-4507-acc1-1298220be98d",
+        "s5ad13266-8abk4-5219-kre5-2811022l7e43dv",
+        "de83fc78-d648-444e-b20d-853bf05e4f0e",
+    ]

--- a/examples/development/sample_data.py
+++ b/examples/development/sample_data.py
@@ -1,0 +1,77 @@
+# Sample data containing multiple text items
+
+BASIC_EXAMPLE = {
+    "session": {
+        "session_id": "719f30a1-03bb-4d41-a654-138da5c43547",
+        "user_id": "193a9e01-8849-4e1f-a42a-a859fa7f2ad3",
+        "user_name_hash": "6511c5688bbb87798128695a283411a26da532df06e6e931a53416e379ddda0e",
+        "platform": "reddit",
+        "cohort": "AB",
+        "url": "https://reddit.com/r/PRCExample/1f4deg/example_to_insert",
+        "current_time": "2024-01-20 18:41:20",
+    },
+    "items": [
+        {
+            "id": "de83fc78-d648-444e-b20d-853bf05e4f0e",
+            "title": "this is the post title, available only on reddit",
+            "text": "this is the worst thing I have ever seen!",
+            "author_name_hash": "60b46b7370f80735a06b7aa8c4eb6bd588440816b086d5ef7355cf202a118305",
+            "embedded_urls": [],
+            "type": "post",
+            "created_at": "2023-12-06 17:02:11",
+            "engagements": {"upvote": 34, "downvote": 27, "comment": 20, "award": 0},
+        },
+        {
+            "id": "s5ad13266-8abk4-5219-kre5-2811022l7e43dv",
+            "post_id": "de83fc78-d648-444e-b20d-853bf05e4f0e",
+            "parent_id": "",
+            "text": "this is amazing!",
+            "author_name_hash": "60b46b7370f80735a06b7aa8c4eb6bd588440816b086d5ef7355cf202a118305",
+            "embedded_urls": [],
+            "type": "comment",
+            "created_at": "2023-12-08 11:32:12",
+            "engagements": {"upvote": 15, "downvote": 2, "comment": 22, "award": 2},
+        },
+        {
+            "id": "a4c08177-8db2-4507-acc1-1298220be98d",
+            "post_id": "de83fc78-d648-444e-b20d-853bf05e4f0e",
+            "parent_id": "s5ad13266-8abk4-5219-kre5-2811022l7e43dv",
+            "text": "this thing is ok.",
+            "author_name_hash": "60b46b7370f80735a06b7aa8c4eb6bd588440816b086d5ef7355cf202a118305",
+            "embedded_urls": [],
+            "type": "comment",
+            "created_at": "2023-12-08 11:35:00",
+            "engagements": {"upvote": 3, "downvote": 5, "comment": 10, "award": 0},
+        },
+    ],
+}
+
+# some new posts that can be added to the response
+NEW_POSTS = {
+    "facebook": [
+        {
+            "id": "8355449941171896",
+            "url": "https://www.facebook.com/deborah.neher/posts/pfbid02Ehfoh4rYW9YfvHfit1ZVKe8WT6tfhhPHCXXrYNsJyG1GnkFVZBfvm6aubcMMz8SFl",
+        },
+    ],
+    "reddit": [
+        {
+            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+            "url": "https://www.reddit.com/r/bestOfReddit/comments/hb55wg/rick_astley_gets_rick_rolled/",
+        },
+        {
+            "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
+            "url": "https://www.reddit.com/r/maru/comments/13co2hm/liquid_maru_with_level_10_of_meltability/",
+        },
+    ],
+    "twitter": [
+        {
+            "id": "571775f3-2564-4cf5-b01c-f4cb6bab461b",
+            "url": "https://twitter.com/Horse_ebooks/status/218439593240956928",
+        },
+        {
+            "id": "1fcbb164-f81f-4532-b068-2561941d0f63",
+            "url": "https://twitter.com/elonmusk/status/1519480761749016577",
+        },
+    ],
+}


### PR DESCRIPTION
This PR adds a new example, which is a ranker that just reorders items (by reversing or randomizing them) and can add and remove items as well. It's useful for developing components that depend on the ranker, like the request router and the browser extension.

Also updated existing examples to show how to handle a text/plain request body, since the extension is switching to that in order to simplify CORS. Expect to receive data from the request router as application/json still, but if you want to test with the extension directly, you'll need to make similar changes in your code.